### PR TITLE
Https schema.org

### DIFF
--- a/examples/1-basic-article/cpld-niso-context.jsonld
+++ b/examples/1-basic-article/cpld-niso-context.jsonld
@@ -12,7 +12,7 @@
         "skos": "http://www.w3.org/2004/02/skos/core#",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "owl": "http://www.w3.org/2002/07/owl#",
-        "schema": "http://schema.org/",
+        "schema": "https://schema.org/",
         "html": "http://www.w3.org/1999/xhtml#",
 
         "cpld": "https://cpld.example.com/schema/cpld/",
@@ -28,7 +28,6 @@
         
 
         "@vocab": "https://cpld.example.com/schema/cpld/",
-        "@language": "en",
         
         "sameAs": {
             "@type": "@id",

--- a/examples/1-basic-article/includes/anno_slim.jsonld
+++ b/examples/1-basic-article/includes/anno_slim.jsonld
@@ -12,7 +12,7 @@
        "iana":    "http://www.iana.org/assignments/relation/",
        "owl":     "http://www.w3.org/2002/07/owl#",
        "as":      "http://www.w3.org/ns/activitystreams#",
-       "schema":  "http://schema.org/",
+       "schema":  "https://schema.org/",
        
        "id":      {"@type": "@id", "@id": "@id"},
        "type":    {"@type": "@id", "@id": "@type"},

--- a/examples/3-packaging/cpld-niso-context.jsonld
+++ b/examples/3-packaging/cpld-niso-context.jsonld
@@ -12,7 +12,7 @@
         "skos": "http://www.w3.org/2004/02/skos/core#",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "owl": "http://www.w3.org/2002/07/owl#",
-        "schema": "http://schema.org/",
+        "schema": "https://schema.org/",
         "html": "http://www.w3.org/1999/xhtml#",
 
         "cpld": "https://cpld.example.com/schema/cpld/",
@@ -28,7 +28,6 @@
         
 
         "@vocab": "https://cpld.example.com/schema/cpld/",
-        "@language": "en",
         
         "sameAs": {
             "@type": "@id",

--- a/examples/3-packaging/includes/anno_slim.jsonld
+++ b/examples/3-packaging/includes/anno_slim.jsonld
@@ -12,7 +12,7 @@
        "iana":    "http://www.iana.org/assignments/relation/",
        "owl":     "http://www.w3.org/2002/07/owl#",
        "as":      "http://www.w3.org/ns/activitystreams#",
-       "schema":  "http://schema.org/",
+       "schema":  "https://schema.org/",
        
        "id":      {"@type": "@id", "@id": "@id"},
        "type":    {"@type": "@id", "@id": "@type"},


### PR DESCRIPTION
Switch to HTTPS for Schema.org URIs as this is what Schema.org uses as well (embedded in the HTML)