### PR TITLE
Namespace Update

### DIFF
--- a/examples/1-basic-article/cpld-niso-context.jsonld
+++ b/examples/1-basic-article/cpld-niso-context.jsonld
@@ -15,9 +15,9 @@
         "schema": "https://schema.org/",
         "html": "http://www.w3.org/1999/xhtml#",
 
-        "cpld": "https://cpld.example.com/schema/cpld/",
+        "cpld": "https://w3id.org/cpld/",
 
-        "nas": "https://cpld.example.com/publishing/schema/nas/",
+        "nas": "https://w3id.org/cpld/article/nas//",
         "service": "https://cpld.example.com/research/service/",
 
 
@@ -27,7 +27,7 @@
         "work": "https://cpld.example.com/thing/Work/",
         
 
-        "@vocab": "https://cpld.example.com/schema/cpld/",
+        "@vocab": "https://w3id.org/cpld/",
         
         "sameAs": {
             "@type": "@id",

--- a/examples/1-basic-article/cpld-niso.html
+++ b/examples/1-basic-article/cpld-niso.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/document/1a2b3c">
+<html>
     <head>
         <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+        <base href="https://cpld.example.com/document/1a2b3c" />
         <meta name="id" content="https://cpld.example.com/document/1a2b3c" />
-        <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+        <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
         <meta name="dcterms.rights" content="Elsevier Inc." />
         <title>A description of approachable magicians: An exploratory study, the voice of the elevated elf</title>
         <link type="application/ld+json" rel="describedby" href="cpld-niso.jsonld" />

--- a/examples/1-basic-article/cpld-niso.jsonld
+++ b/examples/1-basic-article/cpld-niso.jsonld
@@ -1,7 +1,7 @@
 {
     "@context": ["cpld-niso-context.jsonld", "includes/anno_slim.jsonld", { "doc": "https://cpld.example.com/document/1a2b3c#" } ],
     "id": "https://cpld.example.com/document/1a2b3c",
-    "conformsTo": "http://cpld.example.com/schema/cpld/",
+    "conformsTo": "https://w3id.org/cpld/",
     "type": "schema:Article",
     "schema:title": "A description of approachable magicians: An exploratory study, the voice of the elevated elf",
     "rights": "Elsevier Inc.",

--- a/examples/2-data-linking/Example Data Linking Article.html
+++ b/examples/2-data-linking/Example Data Linking Article.html
@@ -6,7 +6,7 @@
       <base href="https://doi.org/10.1088/0000-0000/IOP1"/>
       <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
       <meta name="id" content="https://doi.org/10.1088/0000-0000/IOP1" />
-      <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+      <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
       <meta name="dcterms.rights" content="NISO" />
       <link type="application/ld+json" rel="describedby" href="Example Data Linking Article.jsonld" />
       <title>Bloggs: Example Data Linking Article</title>

--- a/examples/2-data-linking/Example Data Linking Article.html
+++ b/examples/2-data-linking/Example Data Linking Article.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-   <head >
+   <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
       <title>Bloggs: Example Data Linking Article</title>
       <base href="https://doi.org/10.1088/0000-0000/IOP1"/>

--- a/examples/2-data-linking/Example Data Linking Article.jsonld
+++ b/examples/2-data-linking/Example Data Linking Article.jsonld
@@ -1,7 +1,7 @@
 {
     "@context": ["cpld-niso-context.jsonld",{ "doc": "https://doi.org/10.1088/0000-0000/IOP1#" } ],
     "id": "https://doi.org/10.1088/0000-0000/IOP1",
-    "conformsTo": "http://cpld.example.com/schema/cpld/",
+    "conformsTo": "https://w3id.org/cpld/",
     "type": "schema:Article",
     "schema:title": "Example Data Linking Article",
     "rights": "IOP Publishing",   

--- a/examples/2-data-linking/cpld-niso-context.jsonld
+++ b/examples/2-data-linking/cpld-niso-context.jsonld
@@ -15,9 +15,9 @@
         "schema": "http://schema.org/",
         "html": "http://www.w3.org/1999/xhtml#",
 
-        "cpld": "https://cpld.example.com/schema/cpld/",
+        "cpld": "https://w3id.org/cpld/",
 
-        "nas": "https://cpld.example.com/publishing/schema/nas/",
+        "nas": "https://w3id.org/cpld/article/nas//",
         "service": "https://cpld.example.com/research/service/",
 
 
@@ -27,7 +27,7 @@
         "work": "https://cpld.example.com/thing/Work/",
         
 
-        "@vocab": "https://cpld.example.com/schema/cpld/",
+        "@vocab": "https://w3id.org/cpld/",
         "@language": "en",
         
         "sameAs": {

--- a/examples/2-data-linking/example2.html
+++ b/examples/2-data-linking/example2.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
-<html xml:base="https://doi.org/10.1088/0000-0000/IOP1">
+<html>
 
 <head>
    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
    <title>Bloggs: Example Data Linking Article</title>
+   <base href="https://doi.org/10.1088/0000-0000/IOP1" />
    <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
    <meta name="id" content="https://doi.org/10.1088/0000-0000/IOP1" />
-   <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+   <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
    <meta name="dcterms.rights" content="NISO" />
    <link type="application/ld+json" rel="describedby" href="example2.jsonld" />
 </head>

--- a/examples/3-packaging/cpld-niso-context.jsonld
+++ b/examples/3-packaging/cpld-niso-context.jsonld
@@ -15,9 +15,9 @@
         "schema": "https://schema.org/",
         "html": "http://www.w3.org/1999/xhtml#",
 
-        "cpld": "https://cpld.example.com/schema/cpld/",
+        "cpld": "https://w3id.org/cpld/",
 
-        "nas": "https://cpld.example.com/publishing/schema/nas/",
+        "nas": "https://w3id.org/cpld/article/nas//",
         "service": "https://cpld.example.com/research/service/",
 
 
@@ -27,7 +27,7 @@
         "work": "https://cpld.example.com/thing/Work/",
         
 
-        "@vocab": "https://cpld.example.com/schema/cpld/",
+        "@vocab": "https://w3id.org/cpld/",
         
         "sameAs": {
             "@type": "@id",

--- a/examples/3-packaging/example3.html
+++ b/examples/3-packaging/example3.html
@@ -4,7 +4,7 @@
         <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
         <base href="https://cpld.example.com/document/3a2b3c" />
         <meta name="id" content="https://cpld.example.com/document/3a2b3c" />
-        <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+        <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
         <meta name="dcterms.rights" content="NISO" />
         <title>A very simple example to showcase "packaging"</title>
         <link type="application/ld+json" rel="describedby" href="example3.jsonld" />

--- a/examples/3-packaging/example3.jsonld
+++ b/examples/3-packaging/example3.jsonld
@@ -1,7 +1,7 @@
 {
     "@context": [{ "@version": 1.1, "doc": "https://cpld.example.com/document/3a2b3c#" }, "cpld-niso-context.jsonld", "includes/anno_slim.jsonld"],
     "id": "https://cpld.example.com/document/3a2b3c",
-    "conformsTo": "http://cpld.example.com/schema/cpld/",
+    "conformsTo": "https://w3id.org/cpld/",
     "type": "schema:Article",
     "schema:title": "A very simple example to showcase \"packaging\"",
     "rights": "NISO",

--- a/examples/4-ephemera/blank-page.html
+++ b/examples/4-ephemera/blank-page.html
@@ -3,8 +3,9 @@
 
 <head>
     <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+    <base href="https://ieeexplore.ieee.org/document/8375028" />
     <meta name="id" content="https://ieeexplore.ieee.org/document/8375028" />
-    <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+    <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <meta name="dcterms.rights" content="IEEE" />
     <link type="application/ld+json" rel="describedby" href="blank-page.jsonld" />
     <title>Blank Page</title>

--- a/examples/4-ephemera/blank-page.jsonld
+++ b/examples/4-ephemera/blank-page.jsonld
@@ -13,7 +13,7 @@
         }
     ],
     "id": "https://ieeexplore.ieee.org/document/8375028",
-    "conformsTo": "http://cpld.example.com/schema/cpld/",
+    "conformsTo": "https://w3id.org/cpld/",
     "type": "schema:Article",
     "schema:title": "Blank Page",
     "rights": { "@id": "https://ieee.org" },

--- a/examples/4-ephemera/cpld-niso-context.jsonld
+++ b/examples/4-ephemera/cpld-niso-context.jsonld
@@ -15,9 +15,9 @@
         "schema": "https://schema.org/",
         "html": "http://www.w3.org/1999/xhtml#",
 
-        "cpld": "https://cpld.example.com/schema/cpld/",
+        "cpld": "https://w3id.org/cpld/",
 
-        "nas": "https://cpld.example.com/publishing/schema/nas/",
+        "nas": "https://w3id.org/cpld/article/nas//",
         "service": "https://cpld.example.com/research/service/",
 
 
@@ -27,7 +27,7 @@
         "work": "https://cpld.example.com/thing/Work/",
         
 
-        "@vocab": "https://cpld.example.com/schema/cpld/",
+        "@vocab": "https://w3id.org/cpld/",
         
         "sameAs": {
             "@type": "@id",

--- a/examples/5-tutorial/tutorial.html
+++ b/examples/5-tutorial/tutorial.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/document/3a2b3c">
+<html>
     <head>
+        <base href="https://cpld.example.com/document/3a2b3c" />
         <meta name="id" content="https://cpld.example.com/document/3a2b3c" />
         <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
-        <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+        <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
         <link type="application/ld+json" rel="describedby" href="example1.jsonld" />
     </head>
     <body>

--- a/examples/5-tutorial/tutorial.jsonld
+++ b/examples/5-tutorial/tutorial.jsonld
@@ -6,7 +6,7 @@
     "@graph": [
         {
             "id": "https://cpld.example.com/document/1a2b3c",
-            "conformsTo": "http://cpld.example.com/schema/cpld/",
+            "conformsTo": "https://w3id.org/cpld/",
             "type": "schema:Article",
             "author": {
                 "id": "https://orcid.org/0000-0001-7076-9083",

--- a/examples/5-tutorial/tutorial.md
+++ b/examples/5-tutorial/tutorial.md
@@ -89,7 +89,7 @@ The basic structure of the JSON-LD file (`example1.jsonld`) needs the following 
     ```
 4. We specify (again) that the document conforms to the CP/LD standard:
     ```json
-    "conformsTo": "http://cpld.example.com/schema/cpld/",
+    "conformsTo": "https://w3id.org/cpld/",
     ```
 5. And we specify the type of the document, in this case a [`schema:Article`](https://schema.org/Article):
    ```json
@@ -106,7 +106,7 @@ The complete example:
         { "doc": "https://cpld.example.com/document/1a2b3c#" } 
     ],
     "id": "https://cpld.example.com/document/1a2b3c",
-    "conformsTo": "http://cpld.example.com/schema/cpld/",
+    "conformsTo": "https://w3id.org/cpld/",
     "type": "schema:Article"
 }
 ```
@@ -312,7 +312,7 @@ The full example [HTML](tutorial.html) and [JSON-LD](tutorial.jsonld) are:
     "@graph": [
         {
             "id": "https://cpld.example.com/document/1a2b3c",
-            "conformsTo": "http://cpld.example.com/schema/cpld/",
+            "conformsTo": "https://w3id.org/cpld/",
             "type": "schema:Article",
             "author": {
                 "id": "https://orcid.org/0000-0001-7076-9083",

--- a/examples/5-tutorial/tutorial.md
+++ b/examples/5-tutorial/tutorial.md
@@ -42,7 +42,7 @@ Let's have a look at the basic HTML structure of `example1.html`. To turn this i
     ```
 6. This allows us to then use the `dct` prefix tor stating conformance using the `<meta>` element. We use the pattern described by the [Dublin Core](https://www.dublincore.org/specifications/dublin-core/dc-html/) consortium (note the dot-notation, instead of a colon). **NB** We may also choose to adopt RDFa prefixes instead:
    ```html
-   <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+   <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
    ```
    Note that the value of the `content` attribute should point to the official CP/LD namespace. Additional conformance statements may be added, but this one is required.
 7. Finally, we insert a `<link>` element that points to the JSON-LD file that contains the Linked Data that describes this document:
@@ -60,7 +60,7 @@ In code:
     <head>
         <meta name="id" content="https://cpld.example.com/document/3a2b3c" />
         <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
-        <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+        <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
         <link type="application/ld+json" rel="describedby" href="example1.jsonld" />
     </head>
     <body>
@@ -288,7 +288,7 @@ The full example [HTML](tutorial.html) and [JSON-LD](tutorial.jsonld) are:
     <head>
         <meta name="id" content="https://cpld.example.com/document/3a2b3c" />
         <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
-        <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+        <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
         <link type="application/ld+json" rel="describedby" href="example1.jsonld" />
     </head>
     <body>

--- a/examples/6-article-profile/README.md
+++ b/examples/6-article-profile/README.md
@@ -165,7 +165,7 @@ Usage of properties and entities in the manifest is equivalent to their use in t
 The Scholarly Article data is defined by a set of properties, ontological and narrative entities that describe the essential (meta) data about the article. The properties and ontological entities are are defined by [schema.org](https://schema.org). The narrative entities are defined here.
 
 ### 5.2. Narrative Requirements
-Narrative entity types are defined in the narrative structure vocabulary. They exist in the `nas` namespace (`https://cpld.example.com/publishing/schema/nas/`).
+Narrative entity types are defined in the narrative structure vocabulary. They exist in the `nas` namespace (`https://w3id.org/cpld/article/nas//`).
 
 * Narrative entities MUST be defined in the `doc` namespace, as specified by the CP/LD standard.
 * Narrative entities MUST have a narrative entity type as value for the `type` property.

--- a/schema/cpld.schema.jsonld
+++ b/schema/cpld.schema.jsonld
@@ -60,7 +60,7 @@
         "rdfs:label": "Linked Document",
         "owl:versionInfo": "v1.0",
         "dcat:theme": "Architecture",
-        "vann:preferredNamespaceUri": "https://cpld.example.com/schema/cpld/",
+        "vann:preferredNamespaceUri": "https://w3id.org/cpld/",
         "vann:preferredNamespacePrefix": "cpld",
         "owl:imports": "schema:"
       },

--- a/src/cpld/config.toml
+++ b/src/cpld/config.toml
@@ -1,5 +1,5 @@
 [html]
-validator = "tidy" # Can currently only be 'tidy'
+validator = "tidy" # Can currently only be 'tidy', make sure you have a version of tidy installed that supports html5
 
 [html.tidy]
 input-xml = "true"

--- a/src/cpld/definitions.py
+++ b/src/cpld/definitions.py
@@ -5,7 +5,7 @@ EXAMPLE_IRI_PATTTERN = "https?://example.(com|org)/"
 
 CPLD_SCHEMA_LOCATION = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../schema/cpld.schema.jsonld")
 
-CPLD = Namespace("https://cpld.example.com/schema/cpld/")
+CPLD = Namespace("https://w3id.org/cpld/")
 SCHEMA = Namespace("https://schema.org/")
 
 SH = Namespace("http://www.w3.org/ns/shacl#")

--- a/src/cpld/document.py
+++ b/src/cpld/document.py
@@ -101,7 +101,7 @@ class Document(object):
             raise MissingDCTSchemaDefinitionException()
         
         # Make sure that DC Terms is registered as a schema, and that a conformsTo statement exists in the HTML
-        conforms_to_meta = self._soup.html.head.find("meta", attrs={"name": "dcterms.conformsTo", "content": "https://cpld.example.com/schema/cpld/"})
+        conforms_to_meta = self._soup.html.head.find("meta", attrs={"name": "dcterms.conformsTo", "content": "https://w3id.org/cpld/"})
         if conforms_to_meta is None:
             raise MissingConformsToException()
         

--- a/src/cpld/document.py
+++ b/src/cpld/document.py
@@ -151,11 +151,12 @@ class Document(object):
         if document_iri.endswith("#"):
             raise InvalidHashDocumentIRIException()
 
-        if not "xml:base" in self._soup.html.attrs:
-            raise MissingXMLBaseException()
+        # Make sure that the html base is set.
+        if self._soup.html.head.base is None or not "href" in self._soup.html.head.base.attrs:
+            raise MissingHTMLBaseException()
 
-        if self._soup.html.attrs["xml:base"] != document_iri:
-            raise XMLBaseMismatchException()
+        if self._soup.html.head.base.attrs["href"] != document_iri:
+            raise HTMLBaseMismatchException()
 
         return document_iri
 

--- a/src/cpld/document.py
+++ b/src/cpld/document.py
@@ -12,7 +12,7 @@ from bs4 import BeautifulSoup
 from rfc3987 import parse as rfc3987_parse
 from warnings import warn
 from .definitions import EXAMPLE_IRI_PATTTERN
-from rdflib import ConjunctiveGraph, URIRef, Namespace
+from rdflib import ConjunctiveGraph, URIRef, Namespace, RDF
 import logging
 
 
@@ -211,7 +211,7 @@ class Document(object):
             raise InvalidEmbeddedJSONFoundException() from e
         
         # Load referenced JSON-LD
-        # TODO: Be more restrictive and only find the JSON-LD that has a proper rel="describedby" or rel="preload" or rel="alternate" attribute?
+        # TODO: Be more restrictive and only find the JSON-LD that has a proper rel="preload" attribute?
         for jsonld_tag in self._soup.find_all(
             "link", attrs={"type": "application/ld+json"}
         ):
@@ -259,6 +259,9 @@ class Document(object):
         document_iriref = URIRef(self._document_iri)
         if document_iriref not in self._dataset.all_nodes():
             raise NoStatementsAboutDocumentIRIException()
+
+        if len(list(self._dataset.objects(document_iriref, RDF.type))) == 0 :
+            raise MissingDocumentTypeException()
 
         log.debug(list(self._dataset.namespace_manager.namespaces()))        
 

--- a/src/cpld/exceptions.py
+++ b/src/cpld/exceptions.py
@@ -44,15 +44,15 @@ class MultipleDocumentIRIsException(CPLDException):
     def __init__(self):
         super().__init__("Document specifies more than one '<meta>' element with a value for the 'id' attribute")
 
-class MissingXMLBaseException(CPLDException):
-    """Document does not specify a 'xml:base' attribute on the html root element"""
+class MissingHTMLBaseException(CPLDException):
+    """Document does not specify a 'base' element in the html head"""
     def __init__(self):
-        super().__init__("Document does not specify a 'xml:base' attribute on the html root element")
+        super().__init__("Document does not specify a 'base' element in the html head")
 
-class XMLBaseMismatchException(CPLDException):
-    """Document 'xml:base' attribute does not match the document iri"""
+class HTMLBaseMismatchException(CPLDException):
+    """Document base 'href' attribute does not match the document iri"""
     def __init__(self):
-        super().__init__("Document 'xml:base' attribute does not match the document iri")
+        super().__init__("Document base 'href' attribute does not match the document iri")
 
 class NoJSONLDFoundException(CPLDException):
     """No JSON-LD was found while parsing the Linked Document"""

--- a/src/cpld/exceptions.py
+++ b/src/cpld/exceptions.py
@@ -64,7 +64,10 @@ class NoQuadsFoundException(CPLDException):
     def __init__(self):
         super().__init__("No RDF quads resulted from parsing the JSON-LD")
 
-
+class MissingDocumentTypeException(CPLDException):
+    """No type specified for Document IRI"""
+    def __init__(self):
+        super().__init__("No type specified for Document IRI")
 
 class InvalidEmbeddedJSONFoundException(CPLDException):
     """Could not parse script element content into a JSON object"""

--- a/src/tests/data/1-html-docid-input.html
+++ b/src/tests/data/1-html-docid-input.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/example/minimal">
+<html>
   <head>
     <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+    <base href="https://cpld.example.com/example/minimal" />
     <meta name="id" content="https://cpld.example.com/example/minimal" />
-    <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+    <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <title>Minimal Linked Document</title>
     <script type="application/ld+json">
       {
         "@context": {
-            "cpld": "https://cpld.example.com/schema/cpld/",
+            "cpld": "https://w3id.org/cpld/",
             "schema": "https://schema.org/",
             "sh": "http://www.w3.org/ns/shacl#",
             "dct": "http://purl.org/dc/terms/",
@@ -27,7 +28,7 @@
             "doc": "https://cpld.example.com/example/minimal#"
         },
         "id": "https://cpld.example.com/example/minimal",
-        "conformsTo": ["https://cpld.example.com/schema/cpld/", "https://schema.org/"]
+        "conformsTo": ["https://w3id.org/cpld/", "https://schema.org/"]
       }
     </script>
   </head>

--- a/src/tests/data/2-html-valid-input.html
+++ b/src/tests/data/2-html-valid-input.html
@@ -28,6 +28,7 @@
             "doc": "https://cpld.example.com/example/minimal#"
         },
         "id": "https://cpld.example.com/example/minimal",
+        "type": "schema:CreativeWork",
         "conformsTo": ["https://w3id.org/cpld/", "https://schema.org/"]
       }
     </script>

--- a/src/tests/data/2-html-valid-input.html
+++ b/src/tests/data/2-html-valid-input.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/example/minimal">
+<html>
   <head>
     <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+    <base href="https://cpld.example.com/example/minimal" />
     <meta name="id" content="https://cpld.example.com/example/minimal" />
-    <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+    <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <title>Minimal Linked Document</title>
     <script type="application/ld+json">
       {
         "@context": {
-            "cpld": "https://cpld.example.com/schema/cpld/",
+            "cpld": "https://w3id.org/cpld/",
             "schema": "https://schema.org/",
             "sh": "http://www.w3.org/ns/shacl#",
             "dct": "http://purl.org/dc/terms/",
@@ -27,7 +28,7 @@
             "doc": "https://cpld.example.com/example/minimal#"
         },
         "id": "https://cpld.example.com/example/minimal",
-        "conformsTo": ["https://cpld.example.com/schema/cpld/", "https://schema.org/"]
+        "conformsTo": ["https://w3id.org/cpld/", "https://schema.org/"]
       }
     </script>
   </head>

--- a/src/tests/data/2-html-valid-output.html
+++ b/src/tests/data/2-html-valid-output.html
@@ -28,6 +28,7 @@
             "doc": "https://cpld.example.com/example/minimal#"
         },
         "id": "https://cpld.example.com/example/minimal",
+        "type": "schema:CreativeWork",
         "conformsTo": ["https://w3id.org/cpld/", "https://schema.org/"]
       }
     </script>

--- a/src/tests/data/2-html-valid-output.html
+++ b/src/tests/data/2-html-valid-output.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/example/minimal">
+<html>
   <head>
     <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+    <base href="https://cpld.example.com/example/minimal" />
     <meta name="id" content="https://cpld.example.com/example/minimal" />
-    <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+    <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <title>Minimal Linked Document</title>
     <script type="application/ld+json">
       {
         "@context": {
-            "cpld": "https://cpld.example.com/schema/cpld/",
+            "cpld": "https://w3id.org/cpld/",
             "schema": "https://schema.org/",
             "sh": "http://www.w3.org/ns/shacl#",
             "dct": "http://purl.org/dc/terms/",
@@ -27,7 +28,7 @@
             "doc": "https://cpld.example.com/example/minimal#"
         },
         "id": "https://cpld.example.com/example/minimal",
-        "conformsTo": ["https://cpld.example.com/schema/cpld/", "https://schema.org/"]
+        "conformsTo": ["https://w3id.org/cpld/", "https://schema.org/"]
       }
     </script>
   </head>

--- a/src/tests/data/3-html-invalid-input.html
+++ b/src/tests/data/3-html-invalid-input.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/example/minimal">
+<html>
   <head>
     <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+    <base href="https://cpld.example.com/example/minimal" />
     <meta name="id" content="https://cpld.example.com/example/minimal" />
-    <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+    <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <title>Minimal Linked Document</title>
     <script type="application/ld+json">
       {
         "@context": {
-            "cpld": "https://cpld.example.com/schema/cpld/",
+            "cpld": "https://w3id.org/cpld/",
             "schema": "https://schema.org/",
             "sh": "http://www.w3.org/ns/shacl#",
             "dct": "http://purl.org/dc/terms/",
@@ -27,7 +28,7 @@
             "doc": "https://cpld.example.com/example/minimal#"
         },
         "id": "https://cpld.example.com/example/minimal",
-        "conformsTo": ["https://cpld.example.com/schema/cpld/", "https://schema.org/"]
+        "conformsTo": ["https://w3id.org/cpld/", "https://schema.org/"]
       }
     </script>
   </hed>

--- a/src/tests/data/3b-html-missing-head-input.html
+++ b/src/tests/data/3b-html-missing-head-input.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/example/minimal">
+<html>
   <body>
   </body>
 </html>

--- a/src/tests/data/3c-html-missing-dct-input.html
+++ b/src/tests/data/3c-html-missing-dct-input.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/example/minimal">
+<html>
   <head>
+    <base href="https://cpld.example.com/example/minimal" />
     <meta name="id" content="https://cpld.example.com/example/minimal" />
-    <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+    <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <title>Minimal Linked Document</title>
     <script type="application/ld+json">
       {
         "@context": {
-            "cpld": "https://cpld.example.com/schema/cpld/",
+            "cpld": "https://w3id.org/cpld/",
             "schema": "https://schema.org/",
             "sh": "http://www.w3.org/ns/shacl#",
             "dct": "http://purl.org/dc/terms/",
@@ -26,7 +27,7 @@
             "doc": "https://cpld.example.com/example/minimal#"
         },
         "id": "https://cpld.example.com/example/minimal",
-        "conformsTo": ["https://cpld.example.com/schema/cpld/", "https://schema.org/"]
+        "conformsTo": ["https://w3id.org/cpld/", "https://schema.org/"]
       }
     </script>
   </head>

--- a/src/tests/data/3d-html-missing-conformsTo-input.html
+++ b/src/tests/data/3d-html-missing-conformsTo-input.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/example/minimal">
+<html>
   <head>
+    <base href="https://cpld.example.com/example/minimal" />
     <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
     <meta name="id" content="https://cpld.example.com/example/minimal" />
     <title>Minimal Linked Document</title>
     <script type="application/ld+json">
       {
         "@context": {
-            "cpld": "https://cpld.example.com/schema/cpld/",
+            "cpld": "https://w3id.org/cpld/",
             "schema": "https://schema.org/",
             "sh": "http://www.w3.org/ns/shacl#",
             "dct": "http://purl.org/dc/terms/",
@@ -26,7 +27,7 @@
             "doc": "https://cpld.example.com/example/minimal#"
         },
         "id": "https://cpld.example.com/example/minimal",
-        "conformsTo": ["https://cpld.example.com/schema/cpld/", "https://schema.org/"]
+        "conformsTo": ["https://w3id.org/cpld/", "https://schema.org/"]
       }
     </script>
   </head>

--- a/src/tests/data/4-html-missing-document-id-input.html
+++ b/src/tests/data/4-html-missing-document-id-input.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/example/minimal">
+<html>
   <head>
     <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
-    <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+    <base href="https://cpld.example.com/example/minimal" />
+    <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <title>Minimal Linked Document</title>
     <script type="application/ld+json">
       {
         "@context": {
-            "cpld": "https://cpld.example.com/schema/cpld/",
+            "cpld": "https://w3id.org/cpld/",
             "schema": "https://schema.org/",
             "sh": "http://www.w3.org/ns/shacl#",
             "dct": "http://purl.org/dc/terms/",
@@ -26,7 +27,7 @@
             "doc": "https://cpld.example.com/example/minimal"
         },
         "id": "https://cpld.example.com/example/minimal#",
-        "conformsTo": ["https://cpld.example.com/schema/cpld/", "https://schema.org/"]
+        "conformsTo": ["https://w3id.org/cpld/", "https://schema.org/"]
       }
     </script>
   </head>

--- a/src/tests/data/4b-html-multiple-document-ids-input.html
+++ b/src/tests/data/4b-html-multiple-document-ids-input.html
@@ -1,15 +1,16 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/example/minimal">
+<html>
   <head>
     <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+    <base href="https://cpld.example.com/example/minimal" />
     <meta name="id" content="https://cpld.example.com/example/minimal1" />
     <meta name="id" content="https://cpld.example.com/example/minimal2" />
-    <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+    <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <title>Minimal Linked Document</title>
     <script type="application/ld+json">
       {
         "@context": {
-            "cpld": "https://cpld.example.com/schema/cpld/",
+            "cpld": "https://w3id.org/cpld/",
             "schema": "https://schema.org/",
             "sh": "http://www.w3.org/ns/shacl#",
             "dct": "http://purl.org/dc/terms/",
@@ -28,7 +29,7 @@
             "doc": "https://cpld.example.com/example/minimal#"
         },
         "id": "https://cpld.example.com/example/minimal",
-        "conformsTo": ["https://cpld.example.com/schema/cpld/", "https://schema.org/"]
+        "conformsTo": ["https://w3id.org/cpld/", "https://schema.org/"]
       }
     </script>
   </head>

--- a/src/tests/data/4c-html-invalid-document-id-input.html
+++ b/src/tests/data/4c-html-invalid-document-id-input.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/example/minimal">
+<html>
   <head>
     <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
-    <meta name="id" content="ht tps://data.elsevier.com/example/minimal" />
-    <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+    <base href="https://cpld.example.com/example/minimal" />
+    <meta name="id" content="ht tps://cpld.example.com/example/minimal" />
+    <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <title>Minimal Linked Document</title>
     <script type="application/ld+json">
       {
         "@context": {
-            "cpld": "https://cpld.example.com/schema/cpld/",
+            "cpld": "https://w3id.org/cpld/",
             "schema": "https://schema.org/",
             "sh": "http://www.w3.org/ns/shacl#",
             "dct": "http://purl.org/dc/terms/",
@@ -27,7 +28,7 @@
             "doc": "ht tps://data.elsevier.com/example/minimal"
         },
         "id": "ht tps://data.elsevier.com/example/minimal",
-        "conformsTo": ["https://cpld.example.com/schema/cpld/", "https://schema.org/"]
+        "conformsTo": ["https://w3id.org/cpld/", "https://schema.org/"]
       }
     </script>
   </head>

--- a/src/tests/data/4e-html-invalid-hash-document-id-input.html
+++ b/src/tests/data/4e-html-invalid-hash-document-id-input.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/example/minimal#">
+<html>
   <head>
     <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+    <base href="https://cpld.example.com/example/minimal#" />
     <meta name="id" content="https://cpld.example.com/example/minimal#" />
-    <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+    <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <title>Minimal Linked Document</title>
     <script type="application/ld+json">
       {
         "@context": {
-            "cpld": "https://cpld.example.com/schema/cpld/",
+            "cpld": "https://w3id.org/cpld/",
             "schema": "https://schema.org/",
             "sh": "http://www.w3.org/ns/shacl#",
             "dct": "http://purl.org/dc/terms/",
@@ -27,7 +28,7 @@
             "doc": "https://cpld.example.com/example/minimal#"
         },
         "id": "https://cpld.example.com/example/minimal#",
-        "conformsTo": ["https://cpld.example.com/schema/cpld/", "https://schema.org/"]
+        "conformsTo": ["https://w3id.org/cpld/", "https://schema.org/"]
       }
     </script>
   </head>

--- a/src/tests/data/5a-html-missing-base-input.html
+++ b/src/tests/data/5a-html-missing-base-input.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://data.elsevier.com/example/maximal">
+<html>
   <head>
     <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
-    <meta name="id" content="https://cpld.example.com/example/minimal" />
-    <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+    <meta name="id" content="https://cpld.example.com/example/minimal"></meta>
+    <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <title>Minimal Linked Document</title>
     <script type="application/ld+json">
       {
         "@context": {
-            "cpld": "https://cpld.example.com/schema/cpld/",
+            "cpld": "https://w3id.org/cpld/",
             "schema": "https://schema.org/",
             "sh": "http://www.w3.org/ns/shacl#",
             "dct": "http://purl.org/dc/terms/",
@@ -27,7 +27,7 @@
             "doc": "https://cpld.example.com/example/minimal#"
         },
         "id": "https://cpld.example.com/example/minimal",
-        "conformsTo": ["https://cpld.example.com/schema/cpld/", "https://schema.org/"]
+        "conformsTo": ["https://w3id.org/cpld/", "https://schema.org/"]
       }
     </script>
   </head>

--- a/src/tests/data/5b-html-base-mismatch-input.html
+++ b/src/tests/data/5b-html-base-mismatch-input.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html>
   <head>
     <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
-    <meta name="id" content="https://cpld.example.com/example/minimal"></meta>
-    <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+    <base href="https://cpld.example.com/example/minimal/mismatch" />
+    <meta name="id" content="https://cpld.example.com/example/minimal" />
+    <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <title>Minimal Linked Document</title>
     <script type="application/ld+json">
       {
         "@context": {
-            "cpld": "https://cpld.example.com/schema/cpld/",
+            "cpld": "https://w3id.org/cpld/",
             "schema": "https://schema.org/",
             "sh": "http://www.w3.org/ns/shacl#",
             "dct": "http://purl.org/dc/terms/",
@@ -27,7 +28,7 @@
             "doc": "https://cpld.example.com/example/minimal#"
         },
         "id": "https://cpld.example.com/example/minimal",
-        "conformsTo": ["https://cpld.example.com/schema/cpld/", "https://schema.org/"]
+        "conformsTo": ["https://w3id.org/cpld/", "https://schema.org/"]
       }
     </script>
   </head>

--- a/src/tests/data/6a-jsonld-no-jsonld-found-input.html
+++ b/src/tests/data/6a-jsonld-no-jsonld-found-input.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/example/minimal">
+<html>
   <head>
     <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+    <base href="https://cpld.example.com/example/minimal" />
     <meta name="id" content="https://cpld.example.com/example/minimal" />
-    <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+    <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <title>Minimal Linked Document</title>
   </head>
   <body>

--- a/src/tests/data/6b-jsonld-no-quads-found-input.html
+++ b/src/tests/data/6b-jsonld-no-quads-found-input.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/example/minimal">
+<html>
   <head>
     <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+    <base href="https://cpld.example.com/example/minimal" />
     <meta name="id" content="https://cpld.example.com/example/minimal" />
-    <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+    <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <title>Minimal Linked Document</title>
     <script type="application/ld+json">
       {

--- a/src/tests/data/6c-jsonld-no-statements-about-document-id-found-input.html
+++ b/src/tests/data/6c-jsonld-no-statements-about-document-id-found-input.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/example/minimal">
+<html>
   <head>
     <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+    <base href="https://cpld.example.com/example/minimal" />
     <meta name="id" content="https://cpld.example.com/example/minimal" />
-    <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+    <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <title>Minimal Linked Document</title>
     <script type="application/ld+json">
       {
         "@context": {
-            "cpld": "https://cpld.example.com/schema/cpld/",
+            "cpld": "https://w3id.org/cpld/",
             "schema": "https://schema.org/",
             "sh": "http://www.w3.org/ns/shacl#",
             "dct": "http://purl.org/dc/terms/",
@@ -27,7 +28,7 @@
             "doc": "https://cpld.example.com/example/minimal#"
         },
         "id": "https://data.elsevier.com/and/now/for/something/completely/different",
-        "conformsTo": ["https://cpld.example.com/schema/cpld/", "https://schema.org/"]
+        "conformsTo": ["https://w3id.org/cpld/", "https://schema.org/"]
       }
     </script>
   </head>

--- a/src/tests/data/6d-jsonld-invalid-embedded-json-input.html
+++ b/src/tests/data/6d-jsonld-invalid-embedded-json-input.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/example/minimal">
+<html>
   <head>
     <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+    <base href="https://cpld.example.com/example/minimal" />
     <meta name="id" content="https://cpld.example.com/example/minimal" />
-    <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+    <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <title>Minimal Linked Document</title>
     <script type="application/ld+json">
       { .. this is not valid json .. }

--- a/src/tests/data/6e-jsonld-invalid-linked-local-json-input.html
+++ b/src/tests/data/6e-jsonld-invalid-linked-local-json-input.html
@@ -6,7 +6,7 @@
     <meta name="id" content="https://cpld.example.com/example/minimal" />
     <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <title>Minimal Linked Document</title>
-    <link type="application/ld+json" href="6e-jsonld-invalid-linked-local-json-input.jsonld" />
+    <link type="application/ld+json" rel="preload" href="6e-jsonld-invalid-linked-local-json-input.jsonld" />
   </head>
   <body>
   </body>

--- a/src/tests/data/6e-jsonld-invalid-linked-local-json-input.html
+++ b/src/tests/data/6e-jsonld-invalid-linked-local-json-input.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:base="https://cpld.example.com/example/minimal">
+<html>
   <head>
     <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+    <base href="https://cpld.example.com/example/minimal" />
     <meta name="id" content="https://cpld.example.com/example/minimal" />
-    <meta name="dcterms.conformsTo" content="https://cpld.example.com/schema/cpld/" />
+    <meta name="dcterms.conformsTo" content="https://w3id.org/cpld/" />
     <title>Minimal Linked Document</title>
     <link type="application/ld+json" href="6e-jsonld-invalid-linked-local-json-input.jsonld" />
   </head>

--- a/src/tests/data/6f-jsonld-no-type-on-document-id-found-input.html
+++ b/src/tests/data/6f-jsonld-no-type-on-document-id-found-input.html
@@ -28,7 +28,6 @@
             "doc": "https://cpld.example.com/example/minimal#"
         },
         "id": "https://cpld.example.com/example/minimal",
-        "type": "schema:CreativeWork",
         "conformsTo": ["https://w3id.org/cpld/", "https://schema.org/"]
       }
     </script>

--- a/src/tests/data/manifest.json
+++ b/src/tests/data/manifest.json
@@ -71,18 +71,18 @@
         "raises": "InvalidHashDocumentIRIException"
     },
     {
-        "id": "5a-html-missing-xml-base",
+        "id": "5a-html-missing-base",
         "type": "NegativeTest",
-        "description": "Process HTML document with missing xml:base on html root, and fail to initialize a document object",
-        "input_file": "5a-html-missing-xml-base-input.html",
-        "raises": "MissingXMLBaseException"
+        "description": "Process HTML document with missing base element in the html head, and fail to initialize a document object",
+        "input_file": "5a-html-missing-base-input.html",
+        "raises": "MissingHTMLBaseException"
     },
     {
-        "id": "5b-html-xml-base-mismatch",
+        "id": "5b-html-base-mismatch",
         "type": "NegativeTest",
-        "description": "Process HTML document with xml:base that does not match the document iri, and fail to initialize a document object",
-        "input_file": "5b-html-xml-base-mismatch-input.html",
-        "raises": "XMLBaseMismatchException"
+        "description": "Process HTML document with base href that does not match the document iri, and fail to initialize a document object",
+        "input_file": "5b-html-base-mismatch-input.html",
+        "raises": "HTMLBaseMismatchException"
     },
     {
         "id": "6a-jsonld-no-jsonld-found",

--- a/src/tests/data/manifest.json
+++ b/src/tests/data/manifest.json
@@ -120,6 +120,13 @@
         "raises": "InvalidRemoteJSONFoundException"
     },
     {
+        "id": "6f-jsonld-no-type-on-document-id-found-input",
+        "type": "NegativeTest",
+        "description": "Process HTML document where embedded JSON-LD does not provide a type for the Document IRI",
+        "input_file": "6f-jsonld-no-type-on-document-id-found-input.html",
+        "raises": "MissingDocumentTypeException"
+    },
+    {
         "id": "examples-1-basic-article-docid",
         "type": "RetrievalTest",
         "description": "Extract document ID from example basic article",


### PR DESCRIPTION
This was a pending update to fix the namespace to `https://w3id.org/cpld/`

Also added additional tests for document type.